### PR TITLE
Add fixed version of vertigo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,9 @@ module github.com/czcorpus/vert-tagextract
 
 go 1.14
 
+
 require (
 	github.com/mattn/go-sqlite3 v1.10.0
 	github.com/stretchr/testify v1.6.1
-	github.com/tomachalek/vertigo/v5 v5.0.0
+	github.com/tomachalek/vertigo/v5 v5.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tomachalek/vertigo/v5 v5.0.0 h1:PFAf9iArBwHf0P//fNmQYf//u4pyyH4BCIreRQsM86g=
 github.com/tomachalek/vertigo/v5 v5.0.0/go.mod h1:Kr4P4+S5guPcvro1gzKwjyJSPMLNSaXdCTv5had1xIc=
+github.com/tomachalek/vertigo/v5 v5.0.1 h1:D3HcXx8ygDR5xeI0ysgsC3fIT5xwH5V0+3G6JujhPHE=
+github.com/tomachalek/vertigo/v5 v5.0.1/go.mod h1:Kr4P4+S5guPcvro1gzKwjyJSPMLNSaXdCTv5had1xIc=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
(the prev. version failed to process e.g. czesl-man corpus vertical
file due to excess whitespaces)