### PR TITLE
Export string transformers/modders ...

### DIFF
--- a/proc/inserting.go
+++ b/proc/inserting.go
@@ -73,7 +73,7 @@ type TTExtractor struct {
 	ngramConf          *cnf.NgramConf
 	currSentence       [][]int
 	valueDict          *ptcount.WordDict
-	columnModders      []*modders.ModderChain
+	columnModders      []*modders.StringTransformerChain
 	colCounts          map[string]*ptcount.NgramCounter
 	filter             LineFilter
 	appendMode         bool
@@ -105,7 +105,7 @@ func NewTTExtractor(
 		colgenFn:         colgenFn,
 		ngramConf:        &conf.Ngrams,
 		colCounts:        make(map[string]*ptcount.NgramCounter),
-		columnModders:    make([]*modders.ModderChain, len(conf.Ngrams.AttrColumns)),
+		columnModders:    make([]*modders.StringTransformerChain, len(conf.Ngrams.AttrColumns)),
 		filter:           filter,
 		maxNumErrors:     conf.MaxNumErrors,
 		currSentence:     make([][]int, 0, 20),
@@ -117,11 +117,11 @@ func NewTTExtractor(
 	for i, m := range conf.Ngrams.ColumnMods {
 		values := strings.Split(m, ":")
 		if len(values) > 0 {
-			mod := make([]modders.Modder, 0, len(values))
+			mod := make([]modders.StringTransformer, 0, len(values))
 			for _, v := range values {
-				mod = append(mod, modders.ModderFactory(v))
+				mod = append(mod, modders.StringTransformerFactory(v))
 			}
-			ans.columnModders[i] = modders.NewModderChain(mod)
+			ans.columnModders[i] = modders.NewStringTransformerChain(mod)
 		}
 	}
 	if conf.StackStructEval {

--- a/ptcount/arf.go
+++ b/ptcount/arf.go
@@ -75,14 +75,14 @@ type ARFCalculator struct {
 	counts        map[string]*NgramCounter
 	currSentence  [][]int
 	numTokens     int
-	columnModders []*modders.ModderChain
+	columnModders []*modders.StringTransformerChain
 	wordDict      *WordDict
 	atomStruct    string
 }
 
 // NewARFCalculator is the recommended factory to create an instance of the type
 func NewARFCalculator(counts map[string]*NgramCounter, ngramConf *cnf.NgramConf, numTokens int,
-	columnModders []*modders.ModderChain, wordDict *WordDict, atomStruct string) *ARFCalculator {
+	columnModders []*modders.StringTransformerChain, wordDict *WordDict, atomStruct string) *ARFCalculator {
 	return &ARFCalculator{
 		numTokens:     numTokens,
 		counts:        counts,

--- a/ptcount/modders/chain.go
+++ b/ptcount/modders/chain.go
@@ -20,36 +20,43 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Modder represents a type which is able
+const (
+	TransformerToLower   = "toLower"
+	TransformerIdentity  = "identity"
+	TransformerFirstChar = "firstChar"
+)
+
+// StringTransformer represents a type which is able
 // to modify a string (e.g. to take a substring)
-type Modder interface {
-	Mod(s string) string
+type StringTransformer interface {
+	Transform(s string) string
 }
 
-type ModderChain struct {
-	fn []Modder
+type StringTransformerChain struct {
+	fn []StringTransformer
 }
 
-func NewModderChain(fn []Modder) *ModderChain {
-	return &ModderChain{fn: fn}
+func NewStringTransformerChain(fn []StringTransformer) *StringTransformerChain {
+	return &StringTransformerChain{fn: fn}
 }
 
-func (m *ModderChain) Mod(s string) string {
+func (m *StringTransformerChain) Mod(s string) string {
 	ans := s
 	for _, mod := range m.fn {
-		ans = mod.Mod(ans)
+		ans = mod.Transform(ans)
 	}
 	return ans
 }
 
-func ModderFactory(name string) Modder {
-	if name == "toLower" {
-		return ToLower{}
+func StringTransformerFactory(name string) StringTransformer {
+	switch name {
+	case TransformerToLower:
 
-	} else if name == "firstChar" {
+		return ToLower{}
+	case TransformerFirstChar:
 		return FirstChar{}
 
-	} else if name == "" {
+	case "", TransformerIdentity:
 		return Identity{}
 	}
 	log.Printf("WARNING: unknown modder function %s", name)

--- a/ptcount/modders/modders.go
+++ b/ptcount/modders/modders.go
@@ -20,18 +20,18 @@ import "strings"
 
 type ToLower struct{}
 
-func (m ToLower) Mod(s string) string {
+func (m ToLower) Transform(s string) string {
 	return strings.ToLower(s)
 }
 
 type FirstChar struct{}
 
-func (m FirstChar) Mod(s string) string {
+func (m FirstChar) Transform(s string) string {
 	return s[:1]
 }
 
 type Identity struct{}
 
-func (m Identity) Mod(s string) string {
+func (m Identity) Transform(s string) string {
 	return s
 }


### PR DESCRIPTION
... so library consumers can use respective names safely